### PR TITLE
refactor: make return type always `tuple`

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: "3.8"
 
       - uses: Trim21/setup-poetry@dist/v1
 
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9']
+        python: ["3.6", "3.7", "3.8", "3.9"]
     steps:
       - uses: actions/checkout@v2
 
@@ -41,7 +41,7 @@ jobs:
       - uses: Trim21/install-poetry-project@dist/v1
 
       - name: mypy
-        run: mypy anime_episode_parser
+        run: mypy ./
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -20,4 +20,7 @@ assert (34, 2) == parse_episode(title)
 
 # 34 for episode start
 # 2 for episodes count
+
+title = "something can't parse"
+assert (None, None) == parse_episode(title)
 ```

--- a/anime_episode_parser/__init__.py
+++ b/anime_episode_parser/__init__.py
@@ -1,6 +1,6 @@
 import re
 import logging
-from typing import List, Tuple, Union, Callable
+from typing import List, Tuple, Union, Callable, Optional
 
 from anime_episode_parser.cn import chinese_to_arabic
 
@@ -48,20 +48,19 @@ def episode_range(
     return _0, _1 - _0 + 1
 
 
-def parse_episode(episode_title: str) -> Union[Tuple[int, int], None]:
+def parse_episode(episode_title: str) -> Tuple[Optional[int], Optional[int]]:
     """
     parse episode from title
     :param episode_title: episode title
     :type episode_title: str
-    :return: episode of this title
-    :rtype: int
+    :return: episode of start, episode count
     """
     spare = None
 
     _ = _EPISODE_RANGE_ALL_ZH_1.findall(episode_title)
     if _ and _[0]:
         logger.debug("matching with _EPISODE_RANGE_ALL_ZH_1 '%s'", _)
-        return None
+        return None, None
 
     _ = _EPISODE_RANGE_ALL_ZH_2.findall(episode_title)
     if _ and _[0]:
@@ -122,4 +121,4 @@ def parse_episode(episode_title: str) -> Union[Tuple[int, int], None]:
     if spare:
         return spare, 1
 
-    return None
+    return None, None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import pytest
 
 from anime_episode_parser import parse_episode
 
-_episode_cases: List[Tuple[str, Optional[Tuple[int, int]]]] = [
+_episode_cases: List[Tuple[str, Tuple[Optional[int], Optional[int]]]] = [
     (
         "[YMDR][哥布林殺手][Goblin Slayer][2018][01][1080p][AVC][JAP][BIG5][MP4-AAC][繁中]",
         (1, 1),
@@ -18,9 +18,9 @@ _episode_cases: List[Tuple[str, Optional[Tuple[int, int]]]] = [
     ("【安達與島村】【第01-02話】【1080P】【繁體中文】【AVC】", (1, 2)),
     ("[从零开始的异世界生活 第二季_Re Zero S2][34-35][繁体][720P][MP4]", (34, 2)),
     ("Strike The Blood IV][OVA][05-06][1080P][GB][MP4]", (5, 2)),
-    ("[Legend of the Galactic Heroes 银河英雄传说][全110话+外传+剧场版][MKV][外挂繁中]", None),
-    ("不知道什么片 全二十话", None),
-    ("不知道什么片 全20话", None),
+    ("[Legend of the Galactic Heroes 银河英雄传说][全110话+外传+剧场版][MKV][外挂繁中]", (None, None)),
+    ("不知道什么片 全二十话", (None, None)),
+    ("不知道什么片 全20话", (None, None)),
     ("[银色子弹字幕组][名侦探柯南][第1005集 36格的完美犯罪（后篇）][繁日双语MP4][1080P]", (1005, 1)),
     (
         "[Lilith-Raws] 如果究极进化的完全沉浸 RPG 比现实还更像垃圾游戏的话 "
@@ -42,7 +42,10 @@ _episode_cases: List[Tuple[str, Optional[Tuple[int, int]]]] = [
 
 
 @pytest.mark.parametrize(("title", "episode"), _episode_cases)
-def test_episode_parse(title: str, episode: int) -> None:
+def test_episode_parse(
+    title: str,
+    episode: Tuple[Optional[int], Optional[int]],
+) -> None:
     assert (
         parse_episode(title) == episode
     ), f"\ntitle: {title!r}\nepisode: {episode}\nparsed episode: {parse_episode(title)}"


### PR DESCRIPTION
BREAKING CHANGES:
now `parse_episode()` will always return `tuple`,
and return `(None, None)` for unparseable title.