### PR TITLE
fix: episode with version and between in two space

### DIFF
--- a/anime_episode_parser/__init__.py
+++ b/anime_episode_parser/__init__.py
@@ -17,7 +17,7 @@ _EPISODE_RANGE_ALL_ZH_1 = re.compile(r"[全]([\d-]*?)[話话集]")
 _EPISODE_RANGE_ALL_ZH_2 = re.compile(r"第?(\d*)\s?[-~]\s(\d*)[話话集]")
 
 _EPISODE_OVA_OAD = re.compile(r"([\d]{2,})\s?\((?:OVA|OAD)\)]")
-_EPISODE_WITH_VERSION = re.compile(r"[【\[](\d+)\s? *v\d(?:END)?[】\]]")
+_EPISODE_WITH_VERSION = re.compile(r"[【\[\s](\d+)\s? *v\d(?:END)?[】\]\s]")
 
 _PATTERNS = (
     _EPISODE_ZH,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,6 +47,12 @@ _episode_cases: List[Tuple[str, Tuple[Optional[int], Optional[int]]]] = [
         (3, 1),
     ),
     (
+        "[喵萌Production&LoliHouse] 偶像大师 灰姑娘女孩 U149 / "
+        "THE IDOLM@STER CINDERELLA GIRLS U149 - 04v2 [WebRip 1080p HEVC-10bit AAC]"
+        "[简繁日内封字幕]",
+        (4, 1),
+    ),
+    (
         "[星火字幕组][填坑][2017-03-18&2017-3-24][名侦探柯南][853-854][樱花班的回忆][生肉无字幕[1080P][MP4]",
         (853, 2),
     ),


### PR DESCRIPTION
兼用了下这种带版本号又位于俩空格之间的剧集数格式，测试也加上了，看着应该没影响到其他格式的处理。
```
 [喵萌Production&LoliHouse] 偶像大师 灰姑娘女孩 U149 / THE IDOLM@STER CINDERELLA GIRLS U149 - 04v2 [WebRip 1080p HEVC-10bit AAC][简繁日内封字幕]
```