### PR TITLE
fix(parser): support season episode title formats

### DIFF
--- a/anime_episode_parser/__init__.py
+++ b/anime_episode_parser/__init__.py
@@ -10,7 +10,12 @@ _EPISODE_ZH = re.compile(r"第?\s?(\d{1,4})\s?[話话集]")
 _EPISODE_ALL_ZH = re.compile(r"第([^第]*?)[話话集]")
 _EPISODE_ONLY_NUM = re.compile(r"^([\d]{2,})$")
 _EPISODE_WITH_EP = re.compile(r"EP([\d]{2,})")
-_EPISODE_WITH_SEASON = re.compile(r"S\d+E([\d]{2,})")
+_EPISODE_WITH_SEASON = re.compile(r"\bS\d{1,2}E(\d{1,4})\b", re.IGNORECASE)
+_EPISODE_WITH_SEASON_WORDS = re.compile(
+    r"\bSeason\s+\d{1,2}\s+Episode\s+(\d{1,4})\b",
+    re.IGNORECASE,
+)
+_EPISODE_WITH_SEASON_X = re.compile(r"\b\d{1,2}x(\d{1,4})\b", re.IGNORECASE)
 
 _EPISODE_RANGE = re.compile(r"[^sS]([\d]{2,})\s?[-~]\s?([\d]{2,})")
 _EPISODE_RANGE_2 = re.compile(r"\[(\d+)-(\d+)]")
@@ -34,6 +39,8 @@ _PATTERNS = (
     _EPISODE_OVA_OAD,
     _EPISODE_WITH_VERSION,
     _EPISODE_WITH_SEASON,
+    _EPISODE_WITH_SEASON_WORDS,
+    _EPISODE_WITH_SEASON_X,
 )
 
 
@@ -101,6 +108,15 @@ def parse_episode(episode_title: str) -> Tuple[Optional[int], Optional[int]]:
     _ = _EPISODE_WITH_EP.findall(episode_title)
     if _:
         return get_real_episode(_), 1
+
+    for regexp in (
+        _EPISODE_WITH_SEASON,
+        _EPISODE_WITH_SEASON_WORDS,
+        _EPISODE_WITH_SEASON_X,
+    ):
+        _ = regexp.findall(episode_title)
+        if _:
+            return get_real_episode(_), 1
 
     rest: List[int] = []
     for i in (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -110,6 +110,58 @@ _episode_cases: List[Tuple[str, Tuple[Optional[int], Optional[int]]]] = [
         "乱马1/2「らんま1/2」Ranma1/2 2024年版 第2期 S02E09 1080p 日英双语-多国字幕",
         (9, 1),
     ),
+    (
+        "I Became a Legend after My 10 Year Long Last Stand S01E2 1080p",
+        (2, 1),
+    ),
+    (
+        "I Became a Legend after My 10 Year Long Last Stand S01E01 1080p",
+        (1, 1),
+    ),
+    (
+        "I Became a Legend after My 10 Year Long Last Stand S01E12 1080p",
+        (12, 1),
+    ),
+    (
+        "I Became a Legend after My 10 Year Long Last Stand s1e1 1080p",
+        (1, 1),
+    ),
+    (
+        "I Became a Legend after My 10 Year Long Last Stand Season 1 Episode 12 1080p",
+        (12, 1),
+    ),
+    (
+        "I Became a Legend after My 10 Year Long Last Stand 1x12 1080p",
+        (12, 1),
+    ),
+    (
+        "THE.GHOST.IN.THE.SHELL.S01E01.EPISODE.01.PROLOGUE.SUPER.SPARTAN.i.1080p.AMZN.WEB-DL.DUAL.DDP2.0.H.264-VARYG.mkv",
+        (1, 1),
+    ),
+    (
+        "I.Became.a.Legend.after.My.10.Year.Long.Last.Stand.S01E02.There.Was.a.Formidable.Foe.Deep.inside.the.Den.1080p.CR.WEB-DL.AAC2.0.H.264-VARYG.mkv",
+        (2, 1),
+    ),
+    (
+        "THE.GHOST.IN.THE.SHELL.S1E1.EPISODE.01.PROLOGUE.1080p.mkv",
+        (1, 1),
+    ),
+    (
+        "the.ghost.in.the.shell.s01e01.episode.01.prologue.1080p.mkv",
+        (1, 1),
+    ),
+    (
+        "the.ghost.in.the.shell.s01e1.episode.01.prologue.1080p.mkv",
+        (1, 1),
+    ),
+    (
+        "the.ghost.in.the.shell.s1e10.episode.10.prologue.1080p.mkv",
+        (10, 1),
+    ),
+    (
+        "I.Became.a.Legend.after.My.10.Year.Long.Last.Stand.1x02.Title.1080p.mkv",
+        (2, 1),
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary
- parse common season/episode formats before generic numeric fallback
- support S1E1/S01E01/s01e1, Season 1 Episode 12, and 1x12 formats
- add regression coverage for dotted release filenames and titles containing unrelated numbers

## Tests
- uv run pytest -q